### PR TITLE
Performance improvements

### DIFF
--- a/magnetico2database/magnetico2database.py
+++ b/magnetico2database/magnetico2database.py
@@ -54,7 +54,7 @@ def insert_torrent_content(pg_cursor, info_hash, creation_date):
 
 def insert_torrent_source(pg_cursor, source, info_hash, creation_date):
     sql_command = ("INSERT INTO torrents_torrent_sources (source, info_hash, published_at, created_at, updated_at) "
-                   "VALUES (%s, %s, %s, %s, %s) ON CONFLICT (source, info_hash) DO NOTHING")
+                   "VALUES (%s, %s, %s, %s, %s) ON CONFLICT DO NOTHING")
     values = (source, info_hash, creation_date, creation_date, creation_date)
     try:
         pg_cursor.execute(sql.SQL(sql_command), values)
@@ -65,7 +65,7 @@ def insert_torrent_source(pg_cursor, source, info_hash, creation_date):
 
 def insert_torrent_files(pg_cursor, info_hash, files_info):
     sql_command = ("INSERT INTO torrent_files (info_hash, index, path, size, created_at, updated_at) "
-                   "VALUES (%s, %s, %s, %s, %s, %s) ON CONFLICT (info_hash, path) DO NOTHING")
+                   "VALUES (%s, %s, %s, %s, %s, %s) ON CONFLICT DO NOTHING")
     try:
         for file_info in files_info:
             pg_cursor.execute(sql.SQL(sql_command), (info_hash,) + file_info + (datetime.now(timezone.utc), datetime.now(timezone.utc)))
@@ -75,7 +75,7 @@ def insert_torrent_files(pg_cursor, info_hash, files_info):
 
 def insert_torrent(pg_cursor, torrent_details):
     sql_command = ("INSERT INTO torrents (info_hash, name, size, private, created_at, updated_at, files_status, files_count) "
-                   "VALUES (%s, %s, %s, %s, %s, %s, %s, %s) ON CONFLICT (info_hash) DO NOTHING")
+                   "VALUES (%s, %s, %s, %s, %s, %s, %s, %s) ON CONFLICT DO NOTHING")
     try:
         pg_cursor.execute(sql.SQL(sql_command), torrent_details)
         return True

--- a/magnetico2database/magnetico2database.py
+++ b/magnetico2database/magnetico2database.py
@@ -230,7 +230,7 @@ def main():
         else:
             tqdm.write("[INFO]|[ARGS]: Please set --add-files to acknowledge your choice.")
             exit(1)
-    if not args.insert_content:
+    if not args.insert_torrent_content:
         tqdm.write(f"[INFO]|[ARGS]: --insert-content is not set. Torrents will not show up in the WebUI until `bitmagnet reprocess` has ran.")
         tqdm.write(f"[INFO]|[ARGS]: Enabling --insert-content makes infohashes directly searchable. Either way does `bitmagnet reprocess` need to run to have them searchable.")
         no_insert_content = input(f"[INFO]|[ARGS]: Do you want to continue without inserting content? [y/n]: ").lower()

--- a/magnetico2database/magnetico2database.py
+++ b/magnetico2database/magnetico2database.py
@@ -278,9 +278,12 @@ def main():
         tqdm.write("[INFO]|[PG]: commiting…")
         pg_conn.commit()
         pg_cursor.close()
-    except BaseException:
-        tqdm.write("[ERROR]: Error when executing SQL, rolling back")
+    except BaseException as e:
+        tqdm.write(f"[ERROR]: Error when executing SQL: {str(e)}. Rolling back")
         pg_conn.rollback()
+        import traceback
+
+        traceback.print_exc()
 
 if __name__ == '__main__':
     main()

--- a/magnetico2database/magnetico2database.py
+++ b/magnetico2database/magnetico2database.py
@@ -274,7 +274,7 @@ def main():
     pg_cursor = pg_conn.cursor()
     try:
         pg_cursor.execute('BEGIN')
-        process_magnetico_database(args.database_path, sqlite_conn, pg_conn, args.source_name.lower(), args.add_files, args.add_files_limit, args.insert_torrent_content, args.import_padding, args.force_import)
+        process_magnetico_database(args.database_path, sqlite_conn, pg_cursor, args.source_name.lower(), args.add_files, args.add_files_limit, args.insert_torrent_content, args.import_padding, args.force_import)
         tqdm.write("[INFO]|[PG]: commiting…")
         pg_conn.commit()
         pg_cursor.close()

--- a/magnetico2database/magnetico2database.py
+++ b/magnetico2database/magnetico2database.py
@@ -221,6 +221,13 @@ def process_magnetico_database(
                         file_details = get_file_details(
                             inserted_torrent, add_files_limit, files, import_padding
                         )
+                        all_empty = all(path == b'' for _, path in file_details)
+                        if all_empty:
+                            if force_import:
+                                tqdm.write(f"[INFO]|[DATA]: Record with id {inserted_torrent[0]} only contains empty filenames, force importing.")
+                            if not force_import:
+                                tqdm.write(f"[INFO]|[DATA]: Record with id {inserted_torrent[0]} only contains empty filenames, skipping.")
+                                continue
                         insert_torrent_files(
                             pg_cursor, inserted_torrent[1], file_details
                         )

--- a/magnetico2database/magnetico2database.py
+++ b/magnetico2database/magnetico2database.py
@@ -44,7 +44,21 @@ def decode_with_fallback(byte_sequence, encodings=('utf-8', 'shift_jis', 'euc_jp
     return byte_sequence.decode('utf-8', errors='replace')
 
 
-def insert_torrent_content(pg_cursor, torrents):    
+def insert_torrent_content(pg_cursor, torrents, copy_manager=None):
+    if copy_manager is not None:
+        copy_manager.copy(
+            [
+                (
+                    torrent[1],
+                    b"[]",
+                    *[datetime.fromtimestamp(torrent[5])] * 2,
+                    [(torrent[1].hex(), [1])],
+                )
+                for torrent in torrents
+            ]
+        )
+        return
+
     sql_command = ("INSERT INTO torrent_contents (info_hash, languages, created_at, updated_at, tsv) "
                    "VALUES %s ON CONFLICT DO NOTHING")
     try:
@@ -242,6 +256,15 @@ def process_magnetico_database(
             "torrents_torrent_sources",
             ("source", "info_hash", "published_at", "created_at", "updated_at"),
         )
+        # This requires a recent version of pgcopy
+        if hasattr(pgcopy.copy, 'tsvector_formatter'):
+            content_copy_manager = pgcopy.CopyManager(
+                pg_cursor.connection,
+                "torrent_contents",
+                ("info_hash", "languages", "created_at", "updated_at", "tsv"),
+            )
+        else:
+            content_copy_manager = None
     else:
         tqdm.write("[INFO]|[Perf]: pgcopy isn't available, insertion will be slower")
         file_copy_manager = source_copy_manager = content_copy_manager = None
@@ -323,7 +346,7 @@ def process_magnetico_database(
 
                 insert_torrent_source(pg_cursor, source_name, inserted, source_copy_manager)
                 if insert_content:
-                    insert_torrent_content(pg_cursor, inserted)
+                    insert_torrent_content(pg_cursor, inserted, content_copy_manager)
             finally:
                 pbar.update(batch_size)
             offset += batch_size


### PR DESCRIPTION
It changes the SQL a lot, but I kept all existing checks

- don't query files torrents are not inserted
- use basic types as much as possible (no strftime, hex)
- run sqlite in batch instead of window

Here are my results, ran on AMD Ryzen Pro 4750G + 16GB RAM on SSD, with a 29 millions magnetico database. Arguments list: `--source-name magnetico --add-files --add-files-limit 200 --insert-content`
- On an empty postgresql target: from 260 it/s to 980 it/s
- On an already filled postgreql target (so a lot of conflicts): from 260 it/s (unchanged) to 6000 it/s

So it's a huge win for pre-filled postgresql target, since this will never query.

**Please double check that I didn't miss something.**
I didn't added #10 in this, but I ran my tests with it.